### PR TITLE
Bug: Handle slash suffix in route path

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Description
+
+please describe the purpose of the pull request, including any background context and links to related issues
+
+If it resolves an existing issue, please include a link to the issue.
+
+Fixes #issuenumber
+
+# Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update

--- a/group.go
+++ b/group.go
@@ -1,7 +1,5 @@
 package pulse
 
-import "fmt"
-
 type Group struct {
 	Prefix string
 	Router *Router
@@ -19,7 +17,6 @@ func (g *Group) Use(middleware Middleware) {
 }
 
 func (g *Group) GET(path string, handlers ...Handler) {
-	fmt.Println(g.Prefix + path)
 	g.Router.Get(g.Prefix+path, handlers...)
 }
 

--- a/router.go
+++ b/router.go
@@ -125,6 +125,10 @@ func (r *Route) match(path string) (bool, map[string]string) {
 	parts := strings.Split(path, "/")
 	routeParts := strings.Split(r.Path, "/")
 
+	if strings.HasSuffix(path, "/") {
+		parts = parts[:len(parts)-1]
+	}
+
 	if len(parts) != len(routeParts) {
 		return false, nil
 	}


### PR DESCRIPTION
# Description

Check If the user has added `/` at the end of the path in the route, prevent its return not found page, and ignore it when handling the route

case: 
```go
router.Get("/users/", func(ctx *Context) error {
  ctx.String("hello")
  return nil
})
```
that return not found when I go to `/user` URL

Fixes #6 

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update